### PR TITLE
"A is '***'" are replaced with "A == '***'" in core/model.py

### DIFF
--- a/combo/blm/core/model.py
+++ b/combo/blm/core/model.py
@@ -13,30 +13,30 @@ class model(object):
         self.stats = ()
 
     def prepare(self, X, t, Psi=None):
-        if self.method is 'exact':
+        if self.method == 'exact':
             inf.exact.prepare(blm=self, X=X, t=t, Psi=Psi)
         else:
             pass
 
     def update_stats(self, x, t, psi=None):
-        if self.method is 'exact':
+        if self.method == 'exact':
             self.stats = inf.exact.update_stats(self, x, t, psi)
         else:
             pass
 
     def get_post_params_mean(self):
-        if self.method is 'exact':
+        if self.method == 'exact':
             self.lik.linear.params = inf.exact.get_post_params_mean(blm=self)
 
     def get_post_fmean(self, X, Psi=None, w=None):
-        if self.method is 'exact':
+        if self.method == 'exact':
             fmu = inf.exact.get_post_fmean(self, X, Psi, w)
         else:
             pass
         return fmu
 
     def sampling(self, w_mu=None, N=1, alpha=1.0):
-        if self.method is 'exact':
+        if self.method == 'exact':
             w_hat = inf.exact.sampling(self, w_mu, N, alpha=alpha)
         else:
             pass
@@ -54,7 +54,7 @@ class model(object):
             * np.random.randn(Xtest.shape[0], N)
 
     def get_post_fcov(self, X, Psi=None, diag=True):
-        if self.method is 'exact':
+        if self.method == 'exact':
             fcov = inf.exact.get_post_fcov(self, X, Psi, diag=True)
         else:
             pass


### PR DESCRIPTION
to avoid syntax warning